### PR TITLE
[msd3 - 11_data_classes] Jedenasty rozdział: Korekta wyjaśnienia dotyczącego funkcji hashCode. Poprawki stylistyczne i inne.

### DIFF
--- a/manuscript/11_data_classes.md
+++ b/manuscript/11_data_classes.md
@@ -2,7 +2,7 @@
 
 W Kotlinie mówimy, że wszystkie klasy dziedziczą po nadrzędnej klasie `Any`, która znajduje się na szczycie hierarchii klas[^11_3]. Metody zdefiniowane w `Any` mogą być wywoływane na wszystkich obiektach. Są to metody:
 * `equals` - używana przy porównywaniu dwóch obiektów za pomocą `==`,
-* `hashCode` - używana przez kolekcje, które korzystają z kodów hash trzymanych w nich obiektów,
+* `hashCode` - używana przez kolekcje, które korzystają z algorytmu hash table,
 * `toString` - używana do reprezentacji obiektu jako stringa, np. w szablonie stringa lub funkcji `print`.
 
 Dzięki tym metodom możemy reprezentować dowolny obiekt jako string lub sprawdzić równość dowolnych dwóch obiektów.
@@ -29,7 +29,7 @@ fun main() {
 
 > Prawdę mówiąc, `Any` jest reprezentowane jako klasa, ale powinno być traktowane jako typ. Weź pod uwagę fakt, że `Any` jest także nadrzędnym typem wszystkich interfejsów, mimo że interfejsy nie mogą dziedziczyć po klasach.
 
-Domyślne implementacje `equals`, `hashCode` i `toString` są oparte na tak zwanym kodzie hash tożsamości (`System.identityHashCode()`). Metoda `equals` zwraca `true` tylko wtedy, gdy dla obu obiektów jest taki sam, co oznacza, że po obu stronach jest ten sam obiekt. Metoda `hashCode` zwraca `identityHashCode`. `toString` generuje string, który zaczyna się od nazwy klasy, a następnie znaku małpy "@", a potem `identityHashCode` w notacji szesnastkowej.
+Domyślne implementacje `equals`, `hashCode` i `toString` są mocno oparte na adresie obiektu w pamięci. Metoda `equals` zwraca `true` tylko wtedy, gdy adres obu obiektów jest taki sam, co oznacza, że po obu stronach jest ten sam obiekt. Metoda `hashCode` zamienia ten adres na liczbę. `toString` generuje string, który zaczyna się od nazwy klasy, a następnie znaku małpy "@", a potem skrótu adresu obiektu w notacji szesnastkowej.
 
 ```kotlin
 class A
@@ -105,7 +105,7 @@ Przeanalizujmy wspomniane wcześniej domyślne metody data klasy oraz różnice 
 
 ### Przekształcanie do stringa
 
-Domyślne przekształcenie `toString` generuje string zaczynającego się od nazwy klasy, a następnie zawierającego znak małpy "@" oraz hash kodu tożsamości w reprezentacji szesnastkowej. Celem tego jest wyświetlenie nazwy klasy oraz określenie, czy dwa stringi reprezentują ten sam obiekt, czy nie.
+Domyślne przekształcenie `toString` generuje string zaczynającego się od nazwy klasy, a następnie zawierającego znak małpy "@" oraz hash adresu w reprezentacji szesnastkowej. Celem tego jest wyświetlenie nazwy klasy oraz określenie, czy dwa stringi reprezentują ten sam obiekt, czy nie.
 
 ```kotlin
 class FakeUserRepository
@@ -190,7 +190,7 @@ Kolejną metodą z klasy `Any` jest `hashCode`, która służy do przekształcen
 * być zgodna z `equals`, więc powinna zwracać tę samą wartość `Int` dla równych obiektów, a także zawsze zwracać ten sam kod hashujący dla tego samego obiektu.
 * rozkładać obiekty jak najbardziej równomiernie w zakresie wszystkich możliwych wartości `Int`.
 
-Domyślny `hashCode` opiera się na hashu tożsamości. Kod hashujący generowany przez modyfikator `data` opiera się na kodach hashujących właściwości głównego konstruktora tego obiektu. Gdy dwa obiekty są równe, ich kody hashujący są również równe. 
+Domyślny `hashCode` opiera się na adresie obiektu w pamięci. Kod hashujący generowany przez modyfikator `data` opiera się na kodach hashujących właściwości głównego konstruktora tego obiektu. Gdy dwa obiekty są równe, ich kody hashujący są również równe. 
 
 ```kotlin
 data class Player(
@@ -384,7 +384,7 @@ Musimy być ostrożni z destrukturyzacją. Przydatne jest stosowanie tych samych
 {width: 84%}
 ![](data_fullname.png)
 
-Destrukturyzacja pojedynczej wartości jest bardzo myląca. Zwłaszcza w funkcji lambda, gdzie nawiasy wokół argumentów w wyrażeniach lambda są, w zależności od gramatyki języka programowania, opcjonalne lub wymagane.
+Destrukturyzacja pojedynczej wartości jest bardzo myląca. Zwłaszcza w funkcji lambda, gdzie nawiasy wokół argumentów w wyrażeniach lambda są, w zależności od języka programowania, opcjonalne lub wymagane.
 
 ```kotlin
 data class User(
@@ -418,7 +418,7 @@ data class Dog(
 fun main() {
    val d1 = Dog("Cookie")
    d1.trained = true
-   println(d1) // Dog(name = Cookie)
+   println(d1) // Dog(name=Cookie)
    // więc nic o właściwości trained
 
    val d2 = d1.copy()

--- a/manuscript/11_data_classes.md
+++ b/manuscript/11_data_classes.md
@@ -2,7 +2,7 @@
 
 W Kotlinie mówimy, że wszystkie klasy dziedziczą po nadrzędnej klasie `Any`, która znajduje się na szczycie hierarchii klas[^11_3]. Metody zdefiniowane w `Any` mogą być wywoływane na wszystkich obiektach. Są to metody:
 * `equals` - używana przy porównywaniu dwóch obiektów za pomocą `==`,
-* `hashCode` - używana przez kolekcje, które korzystają z algorytmu hash table,
+* `hashCode` - używana przez kolekcje, które korzystają z kodów hash trzymanych w nich obiektów,
 * `toString` - używana do reprezentacji obiektu jako stringa, np. w szablonie stringa lub funkcji `print`.
 
 Dzięki tym metodom możemy reprezentować dowolny obiekt jako string lub sprawdzić równość dowolnych dwóch obiektów.
@@ -29,7 +29,7 @@ fun main() {
 
 > Prawdę mówiąc, `Any` jest reprezentowane jako klasa, ale powinno być traktowane jako typ. Weź pod uwagę fakt, że `Any` jest także nadrzędnym typem wszystkich interfejsów, mimo że interfejsy nie mogą dziedziczyć po klasach.
 
-Domyślne implementacje `equals`, `hashCode` i `toString` są mocno oparte na adresie obiektu w pamięci. Metoda `equals` zwraca `true` tylko wtedy, gdy adres obu obiektów jest taki sam, co oznacza, że po obu stronach jest ten sam obiekt. Metoda `hashCode` zamienia ten adres na liczbę. `toString` generuje string, który zaczyna się od nazwy klasy, a następnie znaku małpy "@", a potem skrótu adresu obiektu w notacji szesnastkowej.
+Domyślne implementacje `equals`, `hashCode` i `toString` są oparte na tak zwanym kodzie hash tożsamości (`System.identityHashCode()`). Metoda `equals` zwraca `true` tylko wtedy, gdy dla obu obiektów jest taki sam, co oznacza, że po obu stronach jest ten sam obiekt. Metoda `hashCode` zwraca `identityHashCode`. `toString` generuje string, który zaczyna się od nazwy klasy, a następnie znaku małpy "@", a potem `identityHashCode` w notacji szesnastkowej.
 
 ```kotlin
 class A
@@ -105,7 +105,7 @@ Przeanalizujmy wspomniane wcześniej domyślne metody data klasy oraz różnice 
 
 ### Przekształcanie do stringa
 
-Domyślne przekształcenie `toString` generuje string zaczynającego się od nazwy klasy, a następnie zawierającego znak małpy "@" oraz hash adresu w reprezentacji szesnastkowej. Celem tego jest wyświetlenie nazwy klasy oraz określenie, czy dwa stringi reprezentują ten sam obiekt, czy nie.
+Domyślne przekształcenie `toString` generuje string zaczynającego się od nazwy klasy, a następnie zawierającego znak małpy "@" oraz hash kodu tożsamości w reprezentacji szesnastkowej. Celem tego jest wyświetlenie nazwy klasy oraz określenie, czy dwa stringi reprezentują ten sam obiekt, czy nie.
 
 ```kotlin
 class FakeUserRepository
@@ -186,11 +186,11 @@ override fun equals(other: Any?): Boolean = other is Player &&
 
 ### Kod hashujący
 
-Kolejną metodą z klasy `Any` jest `hashCode`, która służy do przekształcenia obiektu na wartość `Int`. Dzięki metodzie `hashCode`, instancję obiektu można przechowywać w implementacjach struktury danych hash table (co się tłumaczy także jako "tablica mieszająca"), będących częścią wielu popularnych klas, takich jak `HashSet` i `HashMap`. Najważniejsza zasada implementacji `hashCode` mówi, że powinna ona:
+Kolejną metodą z klasy `Any` jest `hashCode`, która służy do przekształcenia obiektu na wartość `Int`. Dzięki metodzie `hashCode` instancję obiektu można przechowywać w implementacjach struktury danych hash table (co się tłumaczy także jako "tablica mieszająca"), będących częścią wielu popularnych klas, takich jak `HashSet` i `HashMap`. Najważniejsza zasada implementacji `hashCode` mówi, że powinna ona:
 * być zgodna z `equals`, więc powinna zwracać tę samą wartość `Int` dla równych obiektów, a także zawsze zwracać ten sam kod hashujący dla tego samego obiektu.
 * rozkładać obiekty jak najbardziej równomiernie w zakresie wszystkich możliwych wartości `Int`.
 
-Domyślny `hashCode` opiera się na adresie obiektu w pamięci. Kod hashujący generowany przez modyfikator `data` opiera się na kodach hashujących właściwości głównego konstruktora tego obiektu. Gdy dwa obiekty są równe, ich kody hashujący są również równe. 
+Domyślny `hashCode` opiera się na hashu tożsamości. Kod hashujący generowany przez modyfikator `data` opiera się na kodach hashujących właściwości głównego konstruktora tego obiektu. Gdy dwa obiekty są równe, ich kody hashujący są również równe. 
 
 ```kotlin
 data class Player(
@@ -290,7 +290,7 @@ fun main() {
 }
 ```
 
-Zauważ, że data klasy nie nadają się dla obiektów, które muszą utrzymywać pewne wymogli dla mutowalnych właściwości. Na przykład, w przypadku poniższego przykładu `User`, klasa nie byłaby w stanie zagwarantować, że wartości `name` i `surname` nie są puste, gdyby te zmienne były mutowalne (czyli zdefiniowane za pomocą `var`). Data klasy doskonale nadają się dla niemutowalnych właściwości, których ograniczenia można sprawdzić podczas tworzenia tych obiektów. W poniższym przykładzie możemy być pewni, że wartości `name` i `surname` nie są puste w instancji `User`.
+Zauważ, że data klasy nie nadają się dla obiektów, które muszą utrzymywać pewne wymogi dla mutowalnych właściwości. Na przykład, w przypadku poniższego przykładu `User`, klasa nie byłaby w stanie zagwarantować, że wartości `name` i `surname` nie są puste, gdyby te zmienne były mutowalne (czyli zdefiniowane za pomocą `var`). Data klasy doskonale nadają się dla niemutowalnych właściwości, których ograniczenia można sprawdzić podczas tworzenia tych obiektów. W poniższym przykładzie możemy być pewni, że wartości `name` i `surname` nie są puste w instancji `User`.
 
 ```kotlin
 data class User(
@@ -326,7 +326,7 @@ fun main() {
 }
 ```
 
-Ten mechanizm opiera się na pozycji, a nie nazwach. Obiekt po prawej stronie znaku równości musi dostarczać funkcji `component1`, `component2`, itp., a zmienne są przypisywane do wyników tych metod.
+Ten mechanizm opiera się na pozycji i kolejności definiowania właściwości, a nie ich nazwach. Obiekt po prawej stronie znaku równości musi dostarczać funkcji `component1`, `component2`, itp., a zmienne są przypisywane do wyników tych metod.
 
 ```kotlin
 val (id, name, pts) = player
@@ -379,12 +379,12 @@ val (name, surname) = elon
 print("To jest $name $surname!") // To jest Elon Reeve!
 ```
 
-Musimy być ostrożni z destrukturyzacją. Przydatne jest stosowanie tych samych nazw jak właściwości głównego konstruktora data klasy. W przypadku nieprawidłowej kolejności zostanie wyświetlone ostrzeżenie IntelliJ/Android Studio. Może być nawet przydatne uaktualnienie tego ostrzeżenia do błędu.
+Musimy być ostrożni z destrukturyzacją. Przydatne jest stosowanie tych samych nazw co właściwości głównego konstruktora data klasy. W przypadku nieprawidłowej kolejności zostanie wyświetlone ostrzeżenie IntelliJ/Android Studio. Może być nawet przydatne uaktualnienie tego ostrzeżenia do błędu.
 
 {width: 84%}
 ![](data_fullname.png)
 
-Destrukturyzacja pojedynczej wartości jest bardzo myląca. Zwłaszcza w funkcji lambda, gdzie nawiasy wokół argumentów w wyrażeniach lambda są w niektórych językach opcjonalne lub wymagane.
+Destrukturyzacja pojedynczej wartości jest bardzo myląca. Zwłaszcza w funkcji lambda, gdzie nawiasy wokół argumentów w wyrażeniach lambda są, w zależności od gramatyki języka programowania, opcjonalne lub wymagane.
 
 ```kotlin
 data class User(
@@ -418,7 +418,7 @@ data class Dog(
 fun main() {
    val d1 = Dog("Cookie")
    d1.trained = true
-   println(d1) // Dog(name=Cookie)
+   println(d1) // Dog(name = Cookie)
    // więc nic o właściwości trained
 
    val d2 = d1.copy()
@@ -428,7 +428,7 @@ fun main() {
 }
 ```
 
-Data klasy powinny przechowywać wszystkie istotne właściwości w swoim głównym konstruktorze. W ciele klasy powinniśmy trzymać tylko nadmiarowe, niemodyfikowalne właściwości, co oznacza właściwości, których wartość jest obliczana na podstawie właściwości głównego konstruktora, takie jak `fullName`, które jest obliczane na podstawie `name` i `surname`. Takie wartości są również ignorowane przez metody data klasy, ale ich wartość zawsze będzie poprawna, ponieważ będzie obliczana podczas tworzenia nowego obiektu.
+Data klasy powinny przechowywać wszystkie istotne właściwości w swoim głównym konstruktorze. W ciele klasy powinniśmy trzymać tylko nadmiarowe, niemodyfikowalne właściwości, co oznacza właściwości, których wartość jest obliczana na podstawie właściwości głównego konstruktora, takie jak `fullName`, czyli właściwość obliczana na podstawie `name` i `surname`. Takie wartości są również ignorowane przez metody data klasy, ale ich wartość zawsze będzie poprawna, ponieważ będzie obliczana podczas tworzenia nowego obiektu.
 
 ```kotlin
 data class FullName(
@@ -499,7 +499,7 @@ fun main() {
 
 Te krotki pozostały, ponieważ są bardzo użyteczne w lokalnych zastosowaniach, takich jak:
 
-* Gdy natychmiast nadajemy wartościom nazwy:
+* Natychmiastowe nadawanie wartościom nazwy:
 
 ```kotlin
 val (description, color) = when {
@@ -509,14 +509,14 @@ val (description, color) = when {
 }
 ```
 
-* Aby reprezentować agregat, który nie jest znany z góry, co jest powszechnym przypadkiem w funkcjach biblioteki standardowej:
+* Reprezentowanie agregatu, który nie jest znany z góry, co jest powszechnym przypadkiem w funkcjach biblioteki standardowej:
 
 ```kotlin
 val (odd, even) = numbers.partition { it % 2 == 1 }
 val map = mapOf(1 to "San Francisco", 2 to "Amsterdam")
 ```
 
-W innych przypadkach preferujemy data klasy. Spójrz na przykład: załóżmy, że potrzebujemy funkcji, która przetwarza pełne imię i nazwisko na imię i nazwisko. Ktoś może reprezentować to imię i nazwisko jako `Pair<String, String>`:
+W innych przypadkach preferujemy użycie data klasy. Spójrz na przykład: załóżmy, że potrzebujemy funkcji, która przetwarza pełne imię i nazwisko na imię i nazwisko. Ktoś może reprezentować to imię i nazwisko jako `Pair<String, String>`:
 
 ```kotlin
 fun String.parseName(): Pair<String, String>? {
@@ -567,7 +567,7 @@ fun main() {
 }
 ```
 
-To prawie nic nie kosztuje i znacznie poprawia funkcję:
+To prawie nic nie kosztuje i znacznie poprawia czytelność i czystość kodu:
 
 * Typ zwracany tej funkcji jest łatwiejszy do zinterpretowania.
 


### PR DESCRIPTION
W opisie funkcji hashCode pojawiło się wyjaśnienie, że jest mocno oparta na adresie obiektu w pamięci. JVM domyślnie zwraca liczbę oznaczającą tzw Identity Hash Code, co przetłumaczylem jako hash kod tożsamości (nie wiem, czy zgrabnie i poprawnie :) Szczególnie w przypadku maszyn i systemów 64-bitowych w celu dokladnego określenia adresu potrzebowalibyśmy wartości Long.

https://github.com/JetBrains/kotlin/blob/924c28507067cbfbf78a6509ea89eabe496e34ca/kotlin-native/runtime/src/main/kotlin/kotlin/Any.kt#L39

https://shipilev.net/jvm/anatomy-quarks/26-identity-hash-code/